### PR TITLE
Add GitHub Action to check for duplicate performance links

### DIFF
--- a/.github/workflows/check-duplicate-link.yml
+++ b/.github/workflows/check-duplicate-link.yml
@@ -1,0 +1,132 @@
+name: Check Duplicate Perf Link
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  check-duplicate:
+    if: contains(github.event.issue.body, '## URL')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm install @actions/glob
+
+      - name: Check for duplicate link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { create } = require('@actions/glob');
+
+            const issueBody = context.payload.issue.body || '';
+
+            // Extract first valid URL from issue body
+            const urlRegex = /https?:\/\/[^\s\)>\]"']+/gi;
+            const urls = issueBody.match(urlRegex);
+
+            if (!urls || urls.length === 0) {
+              console.log('No URL found in issue body');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Thanks for your suggestion! However, I couldn't find a valid URL in your issue. Please make sure to include the full URL of the resource you're suggesting.`
+              });
+              return;
+            }
+
+            const submittedUrl = urls[0].replace(/[.,;:!?]+$/, ''); // Clean trailing punctuation
+            console.log(`Found URL: ${submittedUrl}`);
+
+            // Find all perf-links.json files
+            const globber = await create('**/perf-links.json');
+            const perfLinksFiles = await globber.glob();
+
+            console.log(`Found ${perfLinksFiles.length} perf-links.json files`);
+
+            // Search for duplicate URL across all files
+            let duplicate = null;
+
+            for (const filePath of perfLinksFiles) {
+              if (duplicate) break;
+
+              let perfLinks;
+              try {
+                const content = fs.readFileSync(filePath, 'utf8');
+                perfLinks = JSON.parse(content);
+              } catch (error) {
+                console.log(`Error reading ${filePath}: ${error.message}`);
+                continue;
+              }
+
+              const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+              const relativePath = path.relative(process.cwd(), filePath);
+
+              for (const [year, weeks] of Object.entries(perfLinks)) {
+                for (const [week, links] of Object.entries(weeks)) {
+                  for (const link of links) {
+                    if (link.url === submittedUrl) {
+                      // Find line number
+                      let lineNumber = 1;
+                      for (let i = 0; i < lines.length; i++) {
+                        if (lines[i].includes(`"url": "${submittedUrl}"`)) {
+                          lineNumber = i + 1;
+                          break;
+                        }
+                      }
+                      duplicate = {
+                        title: link.title,
+                        url: link.url,
+                        year,
+                        week,
+                        lineNumber,
+                        filePath: relativePath
+                      };
+                      break;
+                    }
+                  }
+                  if (duplicate) break;
+                }
+                if (duplicate) break;
+              }
+            }
+
+            if (duplicate) {
+              // Add duplicated label
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['duplicated']
+              });
+
+              // Comment about duplicate
+              const fileUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/${duplicate.filePath}#L${duplicate.lineNumber}`;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Thanks for your suggestion! However, this resource is already in our collection. \n\n**"${duplicate.title}"** was added in **${duplicate.year} Week ${duplicate.week}**. \n\nYou can find it here: [${duplicate.filePath}#L${duplicate.lineNumber}](${fileUrl}) \n\nWe appreciate your contribution to the Web Performance community!`
+              });
+
+              console.log(`Duplicate found: ${duplicate.title} at ${duplicate.filePath}:${duplicate.lineNumber}`);
+            } else {
+              // Comment thank you for new suggestion
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `Thanks for suggesting this resource! We'll review it and consider adding it to our collection. \n\n We appreciate your contribution to the Web Performance community!`
+              });
+
+              console.log('No duplicate found, thanked for suggestion');
+            }

--- a/.github/workflows/check-duplicate-link.yml
+++ b/.github/workflows/check-duplicate-link.yml
@@ -2,11 +2,17 @@ name: Check Duplicate Perf Link
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue Number'
+        required: true
+        type: string
 
 jobs:
   check-duplicate:
-    if: contains(github.event.issue.body, '## URL')
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.issue.body, '## URL')
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -26,7 +32,27 @@ jobs:
             const path = require('path');
             const { create } = require('@actions/glob');
 
-            const issueBody = context.payload.issue.body || '';
+            let issueNumber = context.issue.number;
+            let issueBody = context.payload.issue ? context.payload.issue.body : '';
+
+            // Handle manual trigger
+            if (context.eventName === 'workflow_dispatch') {
+              issueNumber = parseInt(context.payload.inputs.issue_number);
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber
+                });
+                issueBody = issue.body;
+              } catch (error) {
+                console.log(`Error fetching issue ${issueNumber}: ${error.message}`);
+                return; // Exit if issue not found
+              }
+            }
+            
+            // Re-assign context issue number for comments
+            context.issue.number = issueNumber;
 
             // Extract first valid URL from issue body
             const urlRegex = /https?:\/\/[^\s\)>\]"']+/gi;
@@ -34,12 +60,16 @@ jobs:
 
             if (!urls || urls.length === 0) {
               console.log('No URL found in issue body');
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: `Thanks for your suggestion! However, I couldn't find a valid URL in your issue. Please make sure to include the full URL of the resource you're suggesting.`
-              });
+              // Only comment if it was an automated run (opened/labeled) or valid manual run
+              // to avoid spamming if testing on empty issues
+              if (issueBody) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `Thanks for your suggestion! However, I couldn't find a valid URL in your issue. Please make sure to include the full URL of the resource you're suggesting.`
+                  });
+              }
               return;
             }
 
@@ -104,7 +134,7 @@ jobs:
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 labels: ['duplicated']
               });
 
@@ -114,7 +144,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: `Thanks for your suggestion! However, this resource is already in our collection. \n\n**"${duplicate.title}"** was added in **${duplicate.year} Week ${duplicate.week}**. \n\nYou can find it here: [${duplicate.filePath}#L${duplicate.lineNumber}](${fileUrl}) \n\nWe appreciate your contribution to the Web Performance community!`
               });
 
@@ -124,7 +154,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: `Thanks for suggesting this resource! We'll review it and consider adding it to our collection. \n\n We appreciate your contribution to the Web Performance community!`
               });
 


### PR DESCRIPTION
## Summary

This PR introduces a new GitHub Action workflow that automatically validates new link suggestions submitted via issues. It prevents duplicate entries by cross-referencing submitted URLs against the existing collection in all `perf-links.json` files.

## Key Features

- **Automatic Trigger**: Runs whenever a new issue is opened.
- **Duplicate Detection**: Scans the issue body for a URL and checks it against the entire history of performance links.
- **Smart Feedback**:
  - If Duplicate: Adds a `duplicated` label and posts a comment linking to the existing entry (including year, week, and file location).
  - If New: Posts a thank-you comment acknowledging the contribution.
- **Input Validation**: Ensures a valid URL is present in the issue before processing.

## How it Works

1. The workflow triggers on `issues: [opened]`.
2. It extracts the first URL found in the issue description.
3. It recursively finds all `perf-links.json` files in the repository.
4. It parses the JSON content and checks if the submitted URL already exists.
5. Based on the result, it interacts with the issue using the `actions/github-script` to label or comment.